### PR TITLE
I've updated langchain and other dependencies to their latest versions.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest==8.4.0

--- a/rmrkl/executor.py
+++ b/rmrkl/executor.py
@@ -7,8 +7,8 @@ from langchain.callbacks.manager import CallbackManagerForChainRun
 
 
 class ExceptionTool(BaseTool):
-    name = "_Exception"
-    description = "Exception tool"
+    name: str = "_Exception"
+    description: str = "Exception tool"
 
     def _run(self, query: str) -> str:
         return query

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url="https://github.com/whitead/robust-mrkl",
     license="MIT",
     packages=["rmrkl"],
-    install_requires=["langchain>=0.0.157"],
+    install_requires=["langchain==0.3.25", "langchain-community", "langchain-experimental"],
     test_suite="tests",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,7 +4,7 @@ from langchain.agents import load_tools
 
 
 def test_agent_init():
-    tools = load_tools(["terminal"])
+    tools = load_tools(["terminal"], allow_dangerous_tools=True)
     responses = [
         "I should use the REPL tool",
         "Action: Python REPL\nAction Input: print(2 + 2)",


### PR DESCRIPTION
Here's what I did:
- Updated langchain to version 0.3.25 in `setup.py`.
- Added `langchain-community` and `langchain-experimental` to `install_requires` in `setup.py`.
- Updated pytest to version 8.4.0 in `dev-requirements.txt`.
- Refactored code in `rmrkl/` to be compatible with the new langchain version.
- Added type annotations in `rmrkl/executor.py`.
- Updated the `load_tools` call in `tests/test_agent.py` to set `allow_dangerous_tools=True`.
- Ensured all tests pass after refactoring.